### PR TITLE
bugfix when transfering bnb to gnosis

### DIFF
--- a/contracts/core/Adapter.sol
+++ b/contracts/core/Adapter.sol
@@ -151,7 +151,9 @@ contract Adapter {
             if (t == getETH()) {
                 redeemBNB(tokenMetadata.vTokens(t), swapAmount, address(this));
                 swapResult = address(this).balance;
-                payable(to).transfer(swapResult);
+
+                (bool success, ) = payable(to).call{value: swapResult}("");
+                require(success, "Transfer failed.");
             } else {
                 redeemToken(
                     tokenMetadata.vTokens(t),
@@ -184,7 +186,8 @@ contract Adapter {
             );
             if (t == getETH()) {
                 IWETH(t).withdraw(swapAmount);
-                payable(to).transfer(swapAmount);
+                (bool success, ) = payable(to).call{value: swapAmount}("");
+                require(success, "Transfer failed.");
                 swapResult = swapAmount;
             } else {
                 swapResult = pancakeSwapRouter.swapExactTokensForETH(
@@ -264,8 +267,10 @@ contract Adapter {
         require(vToken.redeem(_amount) == 0, "redeeming vToken failed");
 
         if (_to != address(this)) {
-            uint256 tokenAmount = address(this).balance;
-            payable(_to).transfer(tokenAmount);
+            (bool success, ) = payable(_to).call{value: address(this).balance}(
+                ""
+            );
+            require(success, "Transfer failed.");
         }
     }
 

--- a/contracts/core/IndexSwap.sol
+++ b/contracts/core/IndexSwap.sol
@@ -203,7 +203,9 @@ contract IndexSwap is TokenBase {
         _mint(msg.sender, tokenAmount);
 
         // refund leftover ETH to user
-        (bool success, ) = msg.sender.call{value: address(this).balance}("");
+        (bool success, ) = payable(msg.sender).call{
+            value: address(this).balance
+        }("");
         require(success, "refund failed");
     }
 

--- a/contracts/core/IndexSwap.sol
+++ b/contracts/core/IndexSwap.sol
@@ -235,21 +235,33 @@ contract IndexSwap is TokenBase {
             );
 
             if (_tokens[i] == adapter.getETH()) {
-                adapter._pullFromVault(
-                    this,
-                    _tokens[i],
-                    amount,
-                    address(adapter)
-                );
                 if (tokenMetadata.vTokens(_tokens[i]) != address(0)) {
+                    adapter._pullFromVault(
+                        this,
+                        _tokens[i],
+                        amount,
+                        address(adapter)
+                    );
+
                     adapter.redeemBNB(
                         tokenMetadata.vTokens(_tokens[i]),
                         amount,
                         msg.sender
                     );
                 } else {
+                    adapter._pullFromVault(
+                        this,
+                        _tokens[i],
+                        amount,
+                        address(this)
+                    );
+
                     IWETH(_tokens[i]).withdraw(amount);
-                    payable(msg.sender).transfer(amount);
+
+                    (bool success, ) = payable(msg.sender).call{value: amount}(
+                        ""
+                    );
+                    require(success, "Transfer failed.");
                 }
             } else {
                 adapter._pullFromVault(

--- a/contracts/rebalance/Rebalancing.sol
+++ b/contracts/rebalance/Rebalancing.sol
@@ -372,7 +372,11 @@ contract Rebalancing is ReentrancyGuard {
                     );
 
                     IWETH(index.getTokens()[i]).withdraw(amount);
-                    payable(msg.sender).transfer(amount);
+
+                    (bool success, ) = payable(msg.sender).call{value: amount}(
+                        ""
+                    );
+                    require(success, "Transfer failed.");
                 }
             } else {
                 if (tokenMetadata.vTokens(index.getTokens()[i]) != address(0)) {

--- a/contracts/rebalance/Rebalancing.sol
+++ b/contracts/rebalance/Rebalancing.sol
@@ -373,9 +373,9 @@ contract Rebalancing is ReentrancyGuard {
 
                     IWETH(index.getTokens()[i]).withdraw(amount);
 
-                    (bool success, ) = payable(msg.sender).call{value: amount}(
-                        ""
-                    );
+                    (bool success, ) = payable(index.treasury()).call{
+                        value: amount
+                    }("");
                     require(success, "Transfer failed.");
                 }
             } else {


### PR DESCRIPTION
After testing everything out...

Investment1: 0x4d54ec0d2828469b6ffe10ad364e2af751b8f110b80047c6d1a5c474b1cc9aca
Investment2: 0x30b930c64bff776a27958fa4d4d7825a3b2c4c9d8395a4f7bbb889393355d77f
Pause: 0x6326ba6dc2228c5bc6c2b3cfc0513c7abcd6268ad3d9e7edef75a51d328ef1e5
Investment is failing!
Unpause: 0x3e10952949db428ea4994f2e7c059134717c54d831e5ffe01909db1bb55c26cf
UpdateWeights: 0x9febc80844f7674f89ab9dad2df8f72e39147cd2bc5ba13933256e2e2e074e76
--> feeModule fails!
UpdateTokens: 0x6103595646d853e4fa76115580d607a51c0693335e172512db19e79c902e5a82
--> feeModule works after removing BNB
Reason:
We are trying to transfer BNB to the safe which is failing (see: https://help.gnosis-safe.io/en/articles/5249851-why-can-t-i-transfer-eth-from-a-contract-into-a-safe)
We do the same in withdrawFund but it works because we're sending it to a MetaMask address.. anyway it's recommended to use .call instead of .transfer (https://luizhamilton29.medium.com/how-to-use-call-value-7b275ec7f568)
So I changed from:
`payable(_to).transfer(address(this).balance);`
to:
```
(bool success,) = payable(treasury).call{value: address(this).balance}("");
require(success, "Transfer failed.");
```

**Also** there was a mistake in withdrawFund.. we're taking the bnb out of the vault and send it to the adapter, the adapter is redeeming the token from venus and sends it to an address _to.. but if it's not a venus token (if we decide not to use it) the value is stuck in the adapter and we try to withdraw (unwrap) and send it to the user but the value will be 0