### PR TITLE
added check if treasury balance is increasing when fee module is exec…

### DIFF
--- a/test/IndexSwap.test.ts
+++ b/test/IndexSwap.test.ts
@@ -12,6 +12,8 @@ import {
   AccessController,
   TokenMetadata,
   VelvetSafeModule,
+  ERC20,
+  VBep20Interface,
 } from "../typechain";
 
 import { chainIdToAddresses } from "../scripts/networkVariables";
@@ -354,8 +356,29 @@ describe.only("Tests for IndexSwap", () => {
         await rebalancing.updateWeights([3333, 6667]);
       });
 
-      it("should charge fees", async () => {
-        await rebalancing.feeModule();
+      it("should charge fees and treasury balance should increase", async () => {
+        const ERC20 = await ethers.getContractFactory("ERC20");
+        const token = ERC20.attach(ethInstance.address);
+
+        const balanceBefore = await token.balanceOf(owner.address);
+
+        const fee = await rebalancing.feeModule();
+        const receipt = await fee.wait();
+
+        let amount;
+
+        if (receipt.events && receipt.events.length > 0) {
+          const lastElement = receipt.events[receipt.events.length - 1];
+
+          if (lastElement.args) {
+            amount = lastElement.args.amount;
+          }
+        }
+
+        const balance = await token.balanceOf(owner.address);
+
+        expect(Number(balance)).to.be.greaterThanOrEqual(Number(amount));
+        expect(Number(balance)).to.be.greaterThanOrEqual(Number(balanceBefore));
       });
 
       it("updateTokens should revert if total Weights not equal 10,000", async () => {

--- a/test/IndexSwap.test.ts
+++ b/test/IndexSwap.test.ts
@@ -284,6 +284,12 @@ describe.only("Tests for IndexSwap", () => {
       });
 
       it("Invest 0.1BNB into Top10 fund", async () => {
+        const VBep20Interface = await ethers.getContractAt(
+          "VBep20Interface",
+          "0xf508fCD89b8bd15579dc79A6827cB4686A3592c8"
+        );
+        const vETHBalanceBefore = await VBep20Interface.balanceOf(safeAddress);
+
         const indexSupplyBefore = await indexSwap.totalSupply();
         //console.log("0.1bnb before", indexSupplyBefore);
         await indexSwap.investInFund({
@@ -293,6 +299,12 @@ describe.only("Tests for IndexSwap", () => {
 
         expect(Number(indexSupplyAfter)).to.be.greaterThanOrEqual(
           Number(indexSupplyBefore)
+        );
+
+        const vETHBalanceAfter = await VBep20Interface.balanceOf(safeAddress);
+
+        expect(Number(vETHBalanceAfter)).to.be.greaterThan(
+          Number(vETHBalanceBefore)
         );
       });
 


### PR DESCRIPTION
Added check if balance of treasury is increasing when feeModule is executed

We cannot check if the balance increases of the amount because the amount is a vToken amount and is exchanged to the underlying token (the amount is higher than the vToken amount)